### PR TITLE
feat: LLM지출 분석 그룹모드에서 비활성화 된 버튼으로 구현

### DIFF
--- a/src/components/expenses/ExpensesPage.tsx
+++ b/src/components/expenses/ExpensesPage.tsx
@@ -293,6 +293,23 @@ const ExpensesPage: React.FC = () => {
     }
   }, [categoryFilter, loadMonthlyTrendData]);
 
+  // 모드 또는 현재 그룹이 변경될 때 데이터 새로고침 (페이지 유지)
+  useEffect(() => {
+    if (!isInitialLoad) { // 초기 로드가 아닐 때만 실행
+      const params = {
+        mode,
+        year: currentMonth.getFullYear(),
+        month: currentMonth.getMonth() + 1,
+        page: currentPage, // 현재 페이지 번호 유지
+        size: 10, // 페이지 사이즈는 기존과 동일하게
+        groupId: mode === "group" ? currentGroup?.id : null,
+        category: categoryFilter === "all" ? undefined : categoryFilter,
+        search: searchTerm || undefined,
+      };
+      loadCombinedExpenses(params);
+    }
+  }, [mode, currentGroup?.id]); // currentGroup.id를 직접 의존성으로 추가
+
   const categoryData = [
     { category: "FOOD", label: "식비", color: "#FF6B6B" },
     { category: "UTILITIES", label: "공과금", color: "#4ECDC4" },


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- feature: LLM 지출분석 그룹모드에서 비활성화 된 버튼으로 구현
(마우스 hover 시 `개인 가계부에서만 가능합니다` 띄움)
- Markdown 양식에 맞춰 description, difficulty 사이에 구문 줄 추가
- fix: 개인 <-> 그룹 왕복 시 가계부 상단 새로고침 안되던 문제 해결

## 📸 스크린샷 (UI 작업일 경우)

![image](https://github.com/user-attachments/assets/0c7713dc-33b6-4fa8-a3bb-e851824c6166)

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #78 와 연결됨