### PR TITLE
fix: 푸터 법적고지 항목 클릭시 스크롤바 두줄 현상

### DIFF
--- a/src/components/legal/LegalModal.tsx
+++ b/src/components/legal/LegalModal.tsx
@@ -11,7 +11,7 @@ interface LegalModalProps {
 const LegalModal: React.FC<LegalModalProps> = ({ isOpen, onClose, title, children }) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} title={title}>
-      <div className="prose max-w-none p-4 max-h-[70vh] overflow-y-auto">
+      <div className="prose max-w-none p-4">
         {children}
       </div>
     </Modal>


### PR DESCRIPTION
## 🚀 PR 내용 요약

> 이 PR에서 어떤 작업을 했는지 간단히 설명해주세요.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 기타

## ✅ 작업 내용 상세

- fix: 푸터 법적고지 항목 클릭시 스크롤바 두줄 현상

## 📸 스크린샷 (UI 작업일 경우)

| 변경 전 | 변경 후 |
|--------|--------|
| <img width="672" width="100" alt="image" src="https://github.com/user-attachments/assets/5bd75d9c-24ca-49ab-a84b-740061348f2f" /> | 
<img width="672" width="100" alt="image" src="https://github.com/user-attachments/assets/cd926f93-d3cc-4a74-b00c-887202885650" />
 |

## 🔍 테스트 결과

- [x] 로컬에서 기능 정상 작동 확인
- [ ] 테스트 코드 추가 완료

## 📝 참고 사항

- 이 PR은 #138 와 연결됨